### PR TITLE
Use probot-metadata for storing snooze config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+.env
+private-key.pem

--- a/etc/defaults.json
+++ b/etc/defaults.json
@@ -1,0 +1,7 @@
+{
+  "probotUsername" : "probot-snooze[bot]",
+  "labelName" : "probot:snooze",
+  "labelColor" : "gray",
+  "defaultFreezeDuration" : 7,
+  "sampleFormat" : "@probot, freeze this thread until 2100-01-01 with 'A message I\\'ll respond with'"
+}

--- a/etc/defaults.json
+++ b/etc/defaults.json
@@ -1,7 +1,0 @@
-{
-  "probotUsername" : "probot-snooze[bot]",
-  "labelName" : "probot:snooze",
-  "labelColor" : "gray",
-  "defaultFreezeDuration" : 7,
-  "sampleFormat" : "@probot, freeze this thread until 2100-01-01 with 'A message I\\'ll respond with'"
-}

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const createScheduler = require('probot-scheduler');
 const Freeze = require('./lib/freeze');
 const formatParser = require('./lib/format-parser');
 const githubHelper = require('./lib/github-helper');
-const defaults = require('./etc/defaults');
+const defaults = require('./lib/defaults');
 
 /* Configuration Variables */
 

--- a/index.js
+++ b/index.js
@@ -43,8 +43,10 @@ module.exports = robot => {
     const config = await context.config('probot-snooze.yml', defaults);
 
     const freeze = new Freeze(context.github, config);
+    const {owner, repo} = context.repo();
+    const q = `label:"${freeze.config.labelName}" repo:${owner}/${repo}`;
 
-    context.github.search.issues({q:'label:' + freeze.config.labelName, repo:context.repo().full_name}).then(resp => {
+    context.github.search.issues({q}).then(resp => {
       resp.data.items.forEach(issue => {
         context.github.issues.getComments(githubHelper.parseCommentURL(issue.comments_url)).then(resp => {
           return freeze.getLastFreeze(resp.data);

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
-const fs = require('fs');
 const createScheduler = require('probot-scheduler');
 const Freeze = require('./lib/freeze');
 const formatParser = require('./lib/format-parser');
 const githubHelper = require('./lib/github-helper');
+const defaults = require('./etc/defaults');
 
 /* Configuration Variables */
 
@@ -14,7 +14,7 @@ module.exports = robot => {
   robot.on('schedule.repository', handleThaw);
 
   async function installationEvent(context) {
-    const config = await context.config('probot-snooze.yml', JSON.parse(fs.readFileSync('./etc/defaults.json', 'utf8')));
+    const config = await context.config('probot-snooze.yml', defaults);
 
     context.github.issues.getLabel(context.repositories_added[0]({
       name: config.labelName}).catch(() => {
@@ -26,7 +26,7 @@ module.exports = robot => {
   }
 
   async function handleFreeze(context) {
-    const config = await context.config('probot-snooze.yml', JSON.parse(fs.readFileSync('./etc/defaults.json', 'utf8')));
+    const config = await context.config('probot-snooze.yml', defaults);
     const freeze = new Freeze(context.github, config);
 
     const comment = context.payload.comment;
@@ -40,7 +40,7 @@ module.exports = robot => {
   }
 
   async function handleThaw(context) {
-    const config = await context.config('probot-snooze.yml', JSON.parse(fs.readFileSync('./etc/defaults.json', 'utf8')));
+    const config = await context.config('probot-snooze.yml', defaults);
 
     const freeze = new Freeze(context.github, config);
 

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = robot => {
       // Issue objects from the API don't include owner/repo params, so
       // setting them here with `context.repo` so we don't have to worry
       // about it later. :/
-      return freeze.checkUnfreeze(context.repo(issue));
+      return freeze.checkUnfreeze(context, context.repo(issue));
     }));
     robot.log('scheduled thaw run complete');
   }

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports = robot => {
         context.github.issues.getComments(githubHelper.parseCommentURL(issue.comments_url)).then(resp => {
           return freeze.getLastFreeze(resp.data);
         }).then(lastFreezeComment => {
-          if (freeze.unfreezable(lastFreezeComment)) {
+          if (lastFreezeComment && freeze.unfreezable(lastFreezeComment)) {
             freeze.unfreeze(issue, formatParser.propFromComment(lastFreezeComment));
           }
         });

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 const createScheduler = require('probot-scheduler');
 const Freeze = require('./lib/freeze');
-const formatParser = require('./lib/format-parser');
-const githubHelper = require('./lib/github-helper');
 const defaults = require('./lib/defaults');
 
 /* Configuration Variables */
@@ -46,17 +44,14 @@ module.exports = robot => {
     const {owner, repo} = context.repo();
     const q = `label:"${freeze.config.labelName}" repo:${owner}/${repo}`;
 
-    context.github.search.issues({q}).then(resp => {
-      resp.data.items.forEach(issue => {
-        context.github.issues.getComments(githubHelper.parseCommentURL(issue.comments_url)).then(resp => {
-          return freeze.getLastFreeze(resp.data);
-        }).then(lastFreezeComment => {
-          if (lastFreezeComment && freeze.unfreezable(lastFreezeComment)) {
-            freeze.unfreeze(issue, formatParser.propFromComment(lastFreezeComment));
-          }
-        });
-      });
-    });
+    const resp = await context.github.search.issues({q});
+
+    await Promise.all(resp.data.items.map(issue => {
+      // Issue objects from the API don't include owner/repo params, so
+      // setting them here with `context.repo` so we don't have to worry
+      // about it later. :/
+      return freeze.checkUnfreeze(context.repo(issue));
+    }));
     robot.log('scheduled thaw run complete');
   }
 };

--- a/index.js
+++ b/index.js
@@ -57,6 +57,6 @@ module.exports = robot => {
         });
       });
     });
-    console.log('scheduled thaw run complete');
+    robot.log('scheduled thaw run complete');
   }
 };

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,8 +1,0 @@
-module.exports = {
-  probotUsername : 'probot-snooze[bot]',
-  labelName : 'probot:snooze',
-  labelColor : 'gray',
-
-  defaultFreezeDuration : 7,
-  sampleFormat : '@probot, freeze this thread until 2100-01-01 with "A message I\'ll response with"'
-};

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,0 +1,7 @@
+module.exports = {
+  probotUsername: (process.env.APP_NAME || 'probot-snooze') + '[bot]',
+  labelName: 'probot:snooze',
+  labelColor: 'gray',
+  defaultFreezeDuration: 7,
+  sampleFormat: '@probot, freeze this thread until 2100-01-01 with "A message I\'ll respond with"'
+};

--- a/lib/format-parser.js
+++ b/lib/format-parser.js
@@ -8,10 +8,10 @@ module.exports = {
   },
 
   parseResponseMessageFromComment(msg) {
-    const expression = 'until .* with "?(.*)"?';
+    const expression = '[remind me]? to (.*)|"(.*)"';
     const match = msg.match(expression);
-    if (match !== null) {
-      return match[1];
+    if (match !== null && !match[0].includes('to snooze')) {
+      return (typeof match[2] === 'undefined' ? match[1] : match[2]);
     }
     return 'Hey, we\'re back awake!';
   },

--- a/lib/format-parser.js
+++ b/lib/format-parser.js
@@ -14,14 +14,5 @@ module.exports = {
       return (typeof match[2] === 'undefined' ? match[1] : match[2]);
     }
     return 'Hey, we\'re back awake!';
-  },
-
-  propFromComment(comment) {
-    const match = comment.body.match('.*<!-- (props = )?(.*)-->');
-    if (match !== null) {
-      return JSON.parse(match[2]);
-    }
-    return {};
   }
-
 };

--- a/lib/freeze.js
+++ b/lib/freeze.js
@@ -42,8 +42,7 @@ module.exports = class Freeze {
       labels.push(this.config.labelName);
     }
 
-    const kv = metadata(context.github, context.issue(), process.env.APP_ID);
-    await kv.set('snooze', props);
+    await metadata(context).set(props);
 
     await this.github.issues.edit(context.issue({
       state: 'closed',
@@ -56,9 +55,8 @@ module.exports = class Freeze {
     }));
   }
 
-  async checkUnfreeze(issue) {
-    const kv = metadata(this.github, issue, process.env.APP_ID);
-    const props = await kv.get('snooze');
+  async checkUnfreeze(context, issue) {
+    const props = await metadata(context, issue).get();
 
     if (moment(props.unfreezeMoment) < moment()) {
       return this.unfreeze(issue, props);

--- a/lib/freeze.js
+++ b/lib/freeze.js
@@ -32,15 +32,9 @@ module.exports = class Freeze {
   }
 
   getLastFreeze(comments) {
-    let mainComment = {};
-    comments.reverse().some(comment => {
-      if (comment.user.login === this.config.probotUsername) {
-        mainComment = comment;
-        return true;
-      }
-      return false;
+    return comments.reverse().find(comment => {
+      return comment.user.login === this.config.probotUsername;
     });
-    return mainComment;
   }
 
   freeze(context, props) {
@@ -57,7 +51,8 @@ module.exports = class Freeze {
     }));
 
     this.github.issues.createComment(context.issue({
-      body: 'Sure thing. I\'ll close this issue for a bit. I\'ll ping you around ' + props.unfreezeMoment.calendar() + ' :clock1: ' +
+      body: 'Sure thing. I\'ll close this issue for a bit. I\'ll ping you around ' +
+      moment(props.unfreezeMoment).calendar() + ' :clock1: ' +
       '<!-- ' + JSON.stringify(props) + '-->'
     }));
   }

--- a/lib/freeze.js
+++ b/lib/freeze.js
@@ -1,4 +1,5 @@
 const moment = require('moment');
+const Bravey = require('bravey');
 const formatParser = require('./format-parser');
 const GitHubHelper = require('./github-helper');
 
@@ -8,22 +9,24 @@ module.exports = class Freeze {
     this.github = github;
     this.config = Object.assign({}, require('./defaults'), config);
     this.logger = config.logger || console;
+
+    this.nlp = this.getSnoozeBravey();
   }
 
   freezable(comment) {
-    const expression = '@probot(-freeze[bot])?.*[freeze|archive|suspend]';
-    if (comment.body.match(expression)) {
-      return true;
-    }
-    return false;
+    return this.nlp.test(comment.body) !== false;
   }
+
   unfreezable(comment) {
     return moment(formatParser.propFromComment(comment).unfreezeMoment) < moment();
   }
+
   propsHelper(assignee, commentBody) {
+    const pd = formatParser.parseDateFromComment(commentBody);
+    // Console.log('parsed this comment: ', commentBody, '\nParsed this date: ', pd, pd.isValid());
     return {
       assignee,
-      unfreezeMoment: formatParser.parseDateFromComment(commentBody) || moment().add(this.config.defaultFreezeDuration, 'days'),
+      unfreezeMoment: pd.isValid() ? pd : moment().add(this.config.defaultFreezeDuration, 'days').format(),
       message: formatParser.parseResponseMessageFromComment(commentBody)
     };
   }
@@ -67,13 +70,60 @@ module.exports = class Freeze {
     const pos = labels.indexOf(frozenLabel);
     labels.splice(pos, 1);
 
-    this.github.issues.edit(Object.assign(GitHubHelper.commentUrlToIssueRequest(issue.comments_url), {
+    this.github.issues.edit(Object.assign(GitHubHelper.parseCommentURL(issue.comments_url), {
       state: 'open',
       labels
     }));
 
-    this.github.issues.createComment(Object.assign(GitHubHelper.commentUrlToIssueRequest(issue.comments_url), {
+    this.github.issues.createComment(Object.assign(GitHubHelper.parseCommentURL(issue.comments_url), {
       body: ':wave: @' + props.assignee + ', ' + props.message
     }));
+  }
+
+  getSnoozeBravey() {
+    const nlp = new Bravey.Nlp.Fuzzy();
+
+    nlp.addIntent('snooze_request', [{entity: 'cognomen', id: 'cognomen'}, {entity: 'command', id: 'command'}, {entity: 'reopen_text', id:'reopen_text'}]);
+
+    const robotEntity =
+  new Bravey.StringEntityRecognizer('cognomen');
+    robotEntity.addMatch('robot', '@probot');
+    robotEntity.addMatch('robot', '@probot-freeze');
+    robotEntity.addMatch('robot', 'probot');
+    robotEntity.addMatch('robot', 'robot');
+
+    const commandEntity =
+  new Bravey.StringEntityRecognizer('command');
+    commandEntity.addMatch('snooze', 'snooze');
+    commandEntity.addMatch('freeze', 'freeze');
+
+    const responseEntity = new Bravey.RegexEntityRecognizer('reopen_text');
+    /* ResponseEntity.addMatch(new RegExp('remind me to (.*) again'), vals  => { */
+    responseEntity.addMatch(new RegExp('foo bar (.*) again'), () => {
+      return undefined;
+    // Return {
+    //   position: 1,
+    //   entity: 'reopen_text',
+    //   value: 'foo',
+    //   string: 'foo',
+    //   priority: .9
+    // };
+    });
+
+  /*  */
+    nlp.addEntity(robotEntity);
+    nlp.addEntity(commandEntity);
+    nlp.addEntity(responseEntity);
+
+  // Nlp.addDocument("{command_name} this issue", "snooze_request", {fromTaggedSentence: true});
+  // nlp.addDocument("{command_name} this thread until dtg", "snooze_request", {fromTaggedSentence: true});
+  // nlp.addDocument("Hey {robot_address}! Will you {command_name} this issue until dtg?", "snooze_request", {fromTaggedSentence: true});
+  // nlp.addDocument("I'm going to pause this for the time being. I'll {command_name} this til dtg", "snooze_request", {fromTaggedSentence: true});
+
+  // nlp.addDocument("", "snooze_request", {fromTaggedSentence: true});
+
+    nlp.addDocument('{cognomen}, {command} this thread until dtg. remind me to {reopen_text}', 'snooze_request');
+
+    return nlp;
   }
 };

--- a/lib/freeze.js
+++ b/lib/freeze.js
@@ -23,7 +23,7 @@ module.exports = class Freeze {
 
   propsHelper(assignee, commentBody) {
     const pd = formatParser.parseDateFromComment(commentBody);
-    // Console.log('parsed this comment: ', commentBody, '\nParsed this date: ', pd, pd.isValid());
+
     return {
       assignee,
       unfreezeMoment: pd.isValid() ? pd : moment().add(this.config.defaultFreezeDuration, 'days').format(),
@@ -80,42 +80,24 @@ module.exports = class Freeze {
 
     nlp.addIntent('snooze_request', [{entity: 'cognomen', id: 'cognomen'}, {entity: 'command', id: 'command'}, {entity: 'reopen_text', id:'reopen_text'}]);
 
-    const robotEntity =
-  new Bravey.StringEntityRecognizer('cognomen');
+    const robotEntity = new Bravey.StringEntityRecognizer('cognomen');
     robotEntity.addMatch('robot', '@probot');
     robotEntity.addMatch('robot', '@probot-freeze');
     robotEntity.addMatch('robot', 'probot');
     robotEntity.addMatch('robot', 'robot');
 
-    const commandEntity =
-  new Bravey.StringEntityRecognizer('command');
+    const commandEntity = new Bravey.StringEntityRecognizer('command');
     commandEntity.addMatch('snooze', 'snooze');
     commandEntity.addMatch('freeze', 'freeze');
 
     const responseEntity = new Bravey.RegexEntityRecognizer('reopen_text');
-    /* ResponseEntity.addMatch(new RegExp('remind me to (.*) again'), vals  => { */
     responseEntity.addMatch(new RegExp('foo bar (.*) again'), () => {
       return undefined;
-    // Return {
-    //   position: 1,
-    //   entity: 'reopen_text',
-    //   value: 'foo',
-    //   string: 'foo',
-    //   priority: .9
-    // };
     });
 
-  /*  */
     nlp.addEntity(robotEntity);
     nlp.addEntity(commandEntity);
     nlp.addEntity(responseEntity);
-
-  // Nlp.addDocument("{command_name} this issue", "snooze_request", {fromTaggedSentence: true});
-  // nlp.addDocument("{command_name} this thread until dtg", "snooze_request", {fromTaggedSentence: true});
-  // nlp.addDocument("Hey {robot_address}! Will you {command_name} this issue until dtg?", "snooze_request", {fromTaggedSentence: true});
-  // nlp.addDocument("I'm going to pause this for the time being. I'll {command_name} this til dtg", "snooze_request", {fromTaggedSentence: true});
-
-  // nlp.addDocument("", "snooze_request", {fromTaggedSentence: true});
 
     nlp.addDocument('{cognomen}, {command} this thread until dtg. remind me to {reopen_text}', 'snooze_request');
 

--- a/lib/freeze.js
+++ b/lib/freeze.js
@@ -5,9 +5,9 @@ const GitHubHelper = require('./github-helper');
 
 module.exports = class Freeze {
 
-  constructor(github, config = {}) {
+  constructor(github, config) {
     this.github = github;
-    this.config = Object.assign({}, require('./defaults'), config);
+    this.config = config;
     this.logger = config.logger || console;
 
     this.nlp = this.getSnoozeBravey();

--- a/lib/freeze.js
+++ b/lib/freeze.js
@@ -1,5 +1,6 @@
 const moment = require('moment');
 const Bravey = require('bravey');
+const metadata = require('probot-metadata');
 const formatParser = require('./format-parser');
 const GitHubHelper = require('./github-helper');
 
@@ -37,7 +38,7 @@ module.exports = class Freeze {
     });
   }
 
-  freeze(context, props) {
+  async freeze(context, props) {
     const labels = context.payload.issue.labels;
     if (GitHubHelper.isLabelOnIssue(
       context.payload.issue,
@@ -45,15 +46,17 @@ module.exports = class Freeze {
       labels.push(this.config.labelName);
     }
 
-    this.github.issues.edit(context.issue({
+    const kv = metadata(context.github, context.issue(), process.env.APP_ID);
+    await kv.set('snooze', props);
+
+    await this.github.issues.edit(context.issue({
       state: 'closed',
       labels
     }));
 
-    this.github.issues.createComment(context.issue({
+    await this.github.issues.createComment(context.issue({
       body: 'Sure thing. I\'ll close this issue for a bit. I\'ll ping you around ' +
-      moment(props.unfreezeMoment).calendar() + ' :clock1: ' +
-      '<!-- ' + JSON.stringify(props) + '-->'
+      moment(props.unfreezeMoment).calendar() + ' :clock1: '
     }));
   }
 

--- a/lib/freeze.js
+++ b/lib/freeze.js
@@ -18,10 +18,6 @@ module.exports = class Freeze {
     return this.nlp.test(comment.body) !== false;
   }
 
-  unfreezable(comment) {
-    return moment(formatParser.propFromComment(comment).unfreezeMoment) < moment();
-  }
-
   propsHelper(assignee, commentBody) {
     const pd = formatParser.parseDateFromComment(commentBody);
 
@@ -60,7 +56,16 @@ module.exports = class Freeze {
     }));
   }
 
-  unfreeze(issue, props) {
+  async checkUnfreeze(issue) {
+    const kv = metadata(this.github, issue, process.env.APP_ID);
+    const props = await kv.get('snooze');
+
+    if (moment(props.unfreezeMoment) < moment()) {
+      return this.unfreeze(issue, props);
+    }
+  }
+
+  async unfreeze(issue, props) {
     const labels = issue.labels;
     const frozenLabel = labels.find(label => {
       return label.name === this.config.labelName;
@@ -68,14 +73,14 @@ module.exports = class Freeze {
     const pos = labels.indexOf(frozenLabel);
     labels.splice(pos, 1);
 
-    this.github.issues.edit(Object.assign(GitHubHelper.parseCommentURL(issue.comments_url), {
-      state: 'open',
-      labels
-    }));
+    const {owner, repo, number} = issue;
 
-    this.github.issues.createComment(Object.assign(GitHubHelper.parseCommentURL(issue.comments_url), {
+    await this.github.issues.edit({owner, repo, number, labels, state: 'open'});
+
+    await this.github.issues.createComment({
+      owner, repo, number,
       body: ':wave: @' + props.assignee + ', ' + props.message
-    }));
+    });
   }
 
   getSnoozeBravey() {

--- a/lib/github-helper.js
+++ b/lib/github-helper.js
@@ -1,22 +1,8 @@
 module.exports = {
-  parseCommentURL(url) {
-    const match = url.match('https://api.github.com/repos/(.*)/(.*)/issues/(.*)/comments');
-    if (match === null) {
-      return {};
-    } else {
-      return {
-        owner:match[1],
-        repo:match[2],
-        number:match[3]
-      };
-    }
-  },
-
   isLabelOnIssue(issue, labelName) {
     const currentLabels = issue.labels.find(elm => {
       return typeof (elm) === 'object' && Object.prototype.hasOwnProperty.call(elm, 'name') && elm.name === labelName;
     });
     return currentLabels;
   }
-
 };

--- a/lib/github-helper.js
+++ b/lib/github-helper.js
@@ -1,5 +1,5 @@
 module.exports = {
-  commentUrlToIssueRequest(url) {
+  parseCommentURL(url) {
     const match = url.match('https://api.github.com/repos/(.*)/(.*)/issues/(.*)/comments');
     if (match === null) {
       return {};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "chrono-node": "^1.3.4",
     "moment": "^2.18.1",
     "probot": "^0.10.0",
+    "probot-metadata": "github:probot/metadata",
     "probot-scheduler": "1.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "test": "mocha && xo --extend probot"
   },
   "dependencies": {
-    "chrono-node": "^1.3.4",
     "bravey": "^0.1.2",
+    "chrono-node": "^1.3.4",
     "moment": "^2.18.1",
-    "probot": "0.9.1",
+    "probot": "^0.10.0",
     "probot-scheduler": "1.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "mocha && xo --extend probot"
   },
   "dependencies": {
-    "chrono-node": "^1.3.1",
+    "chrono-node": "^1.3.4",
+    "bravey": "^0.1.2",
     "js-yaml": "^3.8.3",
     "moment": "^2.18.1",
     "probot": "0.7.5",
@@ -24,7 +25,7 @@
     "xo": "^0.18.0"
   },
   "engines": {
-    "node": ">= 7.7.0",
+    "node": "= 7.8.0",
     "npm": ">= 4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,10 +12,9 @@
   "dependencies": {
     "chrono-node": "^1.3.4",
     "bravey": "^0.1.2",
-    "js-yaml": "^3.8.3",
     "moment": "^2.18.1",
-    "probot": "0.7.5",
-    "probot-visitor": "0.2.0"
+    "probot": "0.9.1",
+    "probot-scheduler": "1.0.2"
   },
   "devDependencies": {
     "eslint-config-probot": ">=0.1.0",

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const expect = require('expect');
 const {createRobot} = require('probot');
 const plugin = require('..');
@@ -224,7 +223,7 @@ perform: true
       {msg:'Thanks for looking into this.\n\nSo i\'m out of office for the next three weeks. I\'m going to snooze this until I get back on 07/21/17.', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment(chrono.parseDate('next three weeks'))}}
     ];
 
-    const freeze = new Freeze(github, JSON.parse(fs.readFileSync('./etc/defaults.json', 'utf8')));
+    const freeze = new Freeze(github, require('../lib/defaults'));
 
     validMessages.forEach(obj => {
       const comment = {
@@ -248,7 +247,7 @@ perform: true
     {msg:'snooze until 07/11/17 at 14:00, and "bug Seth"', props:{assignee: 'baxterthehacker', message: 'bug Seth', unfreezeMoment: moment(chrono.parseDate('07/11/17 at 14:00'))}},
     {msg:'hey @probot, snooze this issue', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment().add(defaultFreezeDuration, 'days').format()}}
       ];
-    const freeze = new Freeze(github, JSON.parse(fs.readFileSync('./etc/defaults.json', 'utf8')));
+    const freeze = new Freeze(github, require('../lib/defaults'));
 
     msgs.forEach(obj => {
       const comment = {

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,5 @@
+process.env.APP_ID = 1;
+
 const expect = require('expect');
 const {createRobot} = require('probot');
 const plugin = require('..');
@@ -52,7 +54,10 @@ perform: true
         createComment: expect.createSpy(),
         getLabel: null, //  Name: freeze.labelName
         createLabel: expect.createSpy(), // Name: freeze.config.labelName,          color: freeze.config.labelColor
-        edit: expect.createSpy()
+        edit: expect.createSpy(),
+        get: expect.createSpy().andReturn(Promise.resolve({data: {
+          body: 'hello world'
+        }}))
       },
       search: {
         issues: expect.createSpy().andReturn(Promise.resolve({
@@ -108,7 +113,7 @@ perform: true
       repo: 'public-repo',
       path: '.github/probot-snooze.yml'
     });
-    expect(github.issues.edit({
+    expect(github.issues.edit).toHaveBeenCalledWith({
       number:2,
       owner: 'baxterthehacker',
       repo: 'public-repo',
@@ -119,14 +124,26 @@ perform: true
         color: 'fc2929'
       },
         'probot:freeze']
-    }));
+    });
 
     expect(github.issues.createComment).toHaveBeenCalledWith({
       number: 2,
       owner: 'baxterthehacker',
       repo: 'public-repo',
-      body: 'Sure thing. I\'ll close this issue for a bit. I\'ll ping you around 07/01/2017 :clock1: ' +
-        '<!-- ' + JSON.stringify({assignee:'baxterthehacker', unfreezeMoment :chrono.parseDate('July 1, 2017 13:30'), message:'Hey, we\'re back awake!'}) + '-->'
+      body: 'Sure thing. I\'ll close this issue for a bit. I\'ll ping you around 07/01/2017 :clock1: '
+    });
+
+    const params = {
+      assignee:'baxterthehacker',
+      unfreezeMoment :chrono.parseDate('July 1, 2017 13:30'),
+      message:'Hey, we\'re back awake!'
+    };
+
+    expect(github.issues.edit).toHaveBeenCalledWith({
+      owner: 'baxterthehacker',
+      repo: 'public-repo',
+      number: 2,
+      body: `hello world\n\n<!-- probot = {"1":{"snooze":${JSON.stringify(params)}}} -->`
     });
   });
 
@@ -159,8 +176,20 @@ perform: true
       number:2,
       owner: 'baxterthehacker',
       repo: 'public-repo',
-      body: 'Sure thing. I\'ll close this issue for a bit. I\'ll ping you around 07/01/2017 :clock1: ' +
-        '<!-- ' + JSON.stringify({assignee:'baxterthehacker', unfreezeMoment :chrono.parseDate('July 1, 2017 13:30'), message:'Hey, we\'re back awake!'}) + '-->'
+      body: 'Sure thing. I\'ll close this issue for a bit. I\'ll ping you around 07/01/2017 :clock1: '
+    });
+
+    const params = {
+      assignee:'baxterthehacker',
+      unfreezeMoment :chrono.parseDate('July 1, 2017 13:30'),
+      message:'Hey, we\'re back awake!'
+    };
+
+    expect(github.issues.edit).toHaveBeenCalledWith({
+      owner: 'baxterthehacker',
+      repo: 'public-repo',
+      number: 2,
+      body: `hello world\n\n<!-- probot = {"1":{"snooze":${JSON.stringify(params)}}} -->`
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const expect = require('expect');
 const {createRobot} = require('probot');
 const plugin = require('..');
@@ -42,7 +43,7 @@ perform: true
             },
             name:'public-repo'
           }, {
-            body:'@probot, we should snooze this for a while, until July 1, 2018 13:30 <!-- {"assignee":"baxterthehacker","unfreezeMoment":"2016-06-01T17:30:00.000Z","message":"Hey, we\'re back awake!"}-->',
+            body:'@probot, we should snooze this for a while, until July 1, 2017 13:30 <!-- {"assignee":"baxterthehacker","unfreezeMoment":"2017-07-01T17:30:00.000Z","message":"Hey, we\'re back awake!"}-->',
             user: {
               login:'probot-snooze[bot]'
             },
@@ -100,7 +101,7 @@ perform: true
   });
 
   it('posts a snooze comment - no label', async () => {
-    commentEvent.payload.comment.body = '@probot, we should snooze this for a while, until July 1, 2018 13:30';
+    commentEvent.payload.comment.body = '@probot, we should snooze this for a while, until July 1, 2017 13:30';
     await robot.receive(commentEvent);
 
     expect(github.repos.getContent).toHaveBeenCalledWith({
@@ -125,13 +126,13 @@ perform: true
       number: 2,
       owner: 'baxterthehacker',
       repo: 'public-repo',
-      body: 'Sure thing. I\'ll close this issue for a bit. I\'ll ping you around 07/01/2018 :clock1: ' +
-        '<!-- ' + JSON.stringify({assignee:'baxterthehacker', unfreezeMoment :chrono.parseDate('July 1, 2018 13:30'), message:'Hey, we\'re back awake!'}) + '-->'
+      body: 'Sure thing. I\'ll close this issue for a bit. I\'ll ping you around 07/01/2017 :clock1: ' +
+        '<!-- ' + JSON.stringify({assignee:'baxterthehacker', unfreezeMoment :chrono.parseDate('July 1, 2017 13:30'), message:'Hey, we\'re back awake!'}) + '-->'
     });
   });
 
   it('posts a snooze comment - with label', async () => {
-    commentEvent.payload.comment.body = '@probot, we should snooze this for a while, until July 1, 2018 13:30';
+    commentEvent.payload.comment.body = '@probot, we should snooze this for a while, until July 1, 2017 13:30';
     commentEvent.payload.issue.labels.push({
       url: 'https://api.github.com/repos/baxterthehacker/public-repo/labels/probot:freeze',
       name: 'probot:freeze',
@@ -159,16 +160,16 @@ perform: true
       number:2,
       owner: 'baxterthehacker',
       repo: 'public-repo',
-      body: 'Sure thing. I\'ll close this issue for a bit. I\'ll ping you around 07/01/2018 :clock1: ' +
-        '<!-- ' + JSON.stringify({assignee:'baxterthehacker', unfreezeMoment :chrono.parseDate('July 1, 2018 13:30'), message:'Hey, we\'re back awake!'}) + '-->'
+      body: 'Sure thing. I\'ll close this issue for a bit. I\'ll ping you around 07/01/2017 :clock1: ' +
+        '<!-- ' + JSON.stringify({assignee:'baxterthehacker', unfreezeMoment :chrono.parseDate('July 1, 2017 13:30'), message:'Hey, we\'re back awake!'}) + '-->'
     });
   });
 
   it('test visitor activation', async () => {
     await robot.receive({
-      event: 'test',
+      event: 'schedule',
       payload: {
-        action: 'visit',
+        action: 'repository',
         repository: {
           owner: {
             login:'baxterthehacker'
@@ -223,7 +224,7 @@ perform: true
       {msg:'Thanks for looking into this.\n\nSo i\'m out of office for the next three weeks. I\'m going to snooze this until I get back on 07/21/17.', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment(chrono.parseDate('next three weeks'))}}
     ];
 
-    const freeze = new Freeze(github, {});
+    const freeze = new Freeze(github, JSON.parse(fs.readFileSync('./etc/defaults.json', 'utf8')));
 
     validMessages.forEach(obj => {
       const comment = {
@@ -247,8 +248,7 @@ perform: true
     {msg:'snooze until 07/11/17 at 14:00, and "bug Seth"', props:{assignee: 'baxterthehacker', message: 'bug Seth', unfreezeMoment: moment(chrono.parseDate('07/11/17 at 14:00'))}},
     {msg:'hey @probot, snooze this issue', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment().add(defaultFreezeDuration, 'days').format()}}
       ];
-
-    const freeze = new Freeze(github, {});
+    const freeze = new Freeze(github, JSON.parse(fs.readFileSync('./etc/defaults.json', 'utf8')));
 
     msgs.forEach(obj => {
       const comment = {

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,3 @@
-process.env.APP_ID = 1;
-
 const expect = require('expect');
 const {createRobot} = require('probot');
 const plugin = require('..');
@@ -47,7 +45,7 @@ perform: true
       search: {
         issues: expect.createSpy().andReturn(Promise.resolve({
           data:{items: [{
-            body: 'hello world\n\n<!-- probot = {"1":{"snooze":{"assignee":"baxterthehacker","unfreezeMoment":"2017-07-01T17:30:00.000Z","message":"Hey, we\'re back awake!"}}} -->',
+            body: 'hello world\n\n<!-- probot = {"1":{"assignee":"baxterthehacker","unfreezeMoment":"2017-07-01T17:30:00.000Z","message":"Hey, we\'re back awake!"}} -->',
             number: 2,
             labels:[{
               url: 'https://api.github.com/repos/baxterthehacker/public-repo/labels/probot:freeze',
@@ -62,6 +60,8 @@ perform: true
     robot.auth = () => Promise.resolve(github);
 
     plugin(robot);
+
+    commentEvent.payload.installation.id = 1;
   });
 
   it('resolves timezone issues with chrono-node', async () => {
@@ -130,7 +130,7 @@ perform: true
       owner: 'baxterthehacker',
       repo: 'public-repo',
       number: 2,
-      body: `hello world\n\n<!-- probot = {"1":{"snooze":${JSON.stringify(params)}}} -->`
+      body: `hello world\n\n<!-- probot = {"1":${JSON.stringify(params)}} -->`
     });
   });
 
@@ -176,7 +176,7 @@ perform: true
       owner: 'baxterthehacker',
       repo: 'public-repo',
       number: 2,
-      body: `hello world\n\n<!-- probot = {"1":{"snooze":${JSON.stringify(params)}}} -->`
+      body: `hello world\n\n<!-- probot = {"1":${JSON.stringify(params)}} -->`
     });
   });
 
@@ -192,7 +192,7 @@ perform: true
           name:'public-repo'
         },
         installation: {
-          id: 13055
+          id: 1
         }}});
     expect(github.repos.getContent).toHaveBeenCalledWith({
       owner: 'baxterthehacker',

--- a/test/index.js
+++ b/test/index.js
@@ -36,21 +36,6 @@ perform: true
           }}))
       },
       issues: {
-        getComments: expect.createSpy().andReturn(Promise.resolve(
-          {data: [{
-            body:'comment 1',
-            user: {
-              login:'baxterthehacker'
-            },
-            name:'public-repo'
-          }, {
-            body:'@probot, we should snooze this for a while, until July 1, 2017 13:30 <!-- {"assignee":"baxterthehacker","unfreezeMoment":"2017-07-01T17:30:00.000Z","message":"Hey, we\'re back awake!"}-->',
-            user: {
-              login:'probot-snooze[bot]'
-            },
-            name:'public-repo'}]
-          }
-        )), // GithubHelper.commentUrlToIssueRequest(issue.comments_url)
         createComment: expect.createSpy(),
         getLabel: null, //  Name: freeze.labelName
         createLabel: expect.createSpy(), // Name: freeze.config.labelName,          color: freeze.config.labelColor
@@ -61,7 +46,9 @@ perform: true
       },
       search: {
         issues: expect.createSpy().andReturn(Promise.resolve({
-          data:{items: [{comments_url:'https://api.github.com/repos/baxterthehacker/public-repo/issues/2/comments',
+          data:{items: [{
+            body: 'hello world\n\n<!-- probot = {"1":{"snooze":{"assignee":"baxterthehacker","unfreezeMoment":"2017-07-01T17:30:00.000Z","message":"Hey, we\'re back awake!"}}} -->',
+            number: 2,
             labels:[{
               url: 'https://api.github.com/repos/baxterthehacker/public-repo/labels/probot:freeze',
               name: 'probot:freeze',
@@ -212,18 +199,17 @@ perform: true
       repo: 'public-repo',
       path: '.github/probot-snooze.yml'
     });
-
     expect(github.issues.edit).toHaveBeenCalledWith({
       labels: [],
       owner: 'baxterthehacker',
       repo: 'public-repo',
-      number: '2',
+      number: 2,
       state: 'open'
     });
     expect(github.issues.createComment).toHaveBeenCalledWith({
       owner: 'baxterthehacker',
       repo: 'public-repo',
-      number: '2',
+      number: 2,
       body: ':wave: @baxterthehacker, Hey, we\'re back awake!'
     });
   });

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,9 @@
 const expect = require('expect');
 const {createRobot} = require('probot');
 const plugin = require('..');
+const moment = require('moment');
+const chrono = require('chrono-node');
+const Freeze = require('../lib/freeze.js');
 const commentEvent = require('./fixtures/issue_comment.created');
 
 describe('PRobot-Snooze ', () => {
@@ -69,6 +72,22 @@ perform: true
     plugin(robot);
   });
 
+  it('resolves timezone issues with chrono-node', async () => {
+/*  Save this code unless we need to review later
+
+    console.log('current time', new Date());
+    console.log('timezon offset', new Date().getTimezoneOffset());
+    // PD reads the date as local.
+    const parseDate = chrono.parseDate('July 1, 2018 13:30');
+    console.log('pd', util.inspect(parseDate, {depth:null}));
+    const mom = moment(parseDate);
+    // Moment returns the date in local
+    console.log('mom', util.inspect(mom, {depth:null}));
+    mom.add(new Date().getTimezoneOffset(), 'minutes');
+    console.log('mom in UTC', util.inspect(mom, {depth:null}));
+    */
+  });
+
   it('posts a generic comment', async () => {
     commentEvent.payload.comment.body = 'no action needed';
     await robot.receive(commentEvent);
@@ -83,6 +102,7 @@ perform: true
   it('posts a snooze comment - no label', async () => {
     commentEvent.payload.comment.body = '@probot, we should snooze this for a while, until July 1, 2018 13:30';
     await robot.receive(commentEvent);
+
     expect(github.repos.getContent).toHaveBeenCalledWith({
       owner: 'baxterthehacker',
       repo: 'public-repo',
@@ -100,12 +120,13 @@ perform: true
       },
         'probot:freeze']
     }));
+
     expect(github.issues.createComment).toHaveBeenCalledWith({
-      number:2,
+      number: 2,
       owner: 'baxterthehacker',
       repo: 'public-repo',
       body: 'Sure thing. I\'ll close this issue for a bit. I\'ll ping you around 07/01/2018 :clock1: ' +
-        '<!-- {"assignee":"baxterthehacker","unfreezeMoment":"2018-07-01T17:30:00.000Z","message":"Hey, we\'re back awake!"}-->'
+        '<!-- ' + JSON.stringify({assignee:'baxterthehacker', unfreezeMoment :chrono.parseDate('July 1, 2018 13:30'), message:'Hey, we\'re back awake!'}) + '-->'
     });
   });
 
@@ -139,7 +160,7 @@ perform: true
       owner: 'baxterthehacker',
       repo: 'public-repo',
       body: 'Sure thing. I\'ll close this issue for a bit. I\'ll ping you around 07/01/2018 :clock1: ' +
-        '<!-- {"assignee":"baxterthehacker","unfreezeMoment":"2018-07-01T17:30:00.000Z","message":"Hey, we\'re back awake!"}-->'
+        '<!-- ' + JSON.stringify({assignee:'baxterthehacker', unfreezeMoment :chrono.parseDate('July 1, 2018 13:30'), message:'Hey, we\'re back awake!'}) + '-->'
     });
   });
 
@@ -176,5 +197,95 @@ perform: true
       number: '2',
       body: ':wave: @baxterthehacker, Hey, we\'re back awake!'
     });
+  });
+
+  it('test valid comments', async () => {
+    const defaultFreezeDuration = 7;
+    const validMessages = [
+      {msg:'@probot, snooze this message until 08/01/2018. Then remind me about this test', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment(new Date('08/01/2018 12:00'))}},
+     {msg:'snooze this issue', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment().add(defaultFreezeDuration, 'days').format()}},
+      {msg:'snooze this thread until next Tuesday', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment(chrono.parseDate('next Tuesday'))}},
+      {msg:'snooze this thread til next Friday', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment(chrono.parseDate('next Friday'))}},
+      {msg:'snooze this until tomorrow at noon', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment(chrono.parseDate('this until tomorrow at noon'))}},
+      {msg:'snooze this until tomorrow at 2:00pm', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment(chrono.parseDate('tomorrow at 2:00pm'))}},
+    /* Various date format parsing */
+     {msg:'snooze until 07/11/17 at 12:00am', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment(chrono.parseDate('07/11/17 at 12:00am'))}},
+      {msg:'snooze until 07/11/17 at 2pm', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment(chrono.parseDate('07/11/17 at 2pm'))}},
+      {msg:'snooze until 07/11/17 at 2:00pm', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment(chrono.parseDate('07/11/17 at 2:00pm'))}},
+      {msg:'snooze until 07/11/17 at 2:30pm', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment(chrono.parseDate('07/11/17 at 2:30pm'))}},
+      {msg:'snooze until 07/11/17 at 14:00', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment(chrono.parseDate('07/11/17 at 14:00'))}},
+      {msg:'snooze until 07/11/17 at 14:30', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment(chrono.parseDate('07/11/17 at 14:30'))}},
+      {msg:'snooze until 07/11/17', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment(chrono.parseDate('07/11/17'))}},
+      {msg:'freeze until 07/11/17 14:00', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment(chrono.parseDate('07/11/17 14:00'))}},
+    /* Full text */
+      {msg:'So i\'m out of office for the next three weeks. I\'m going to snooze this until I get back.', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment(chrono.parseDate('next three weeks'))}},
+      {msg:'So i\'m out of office for the next three weeks. I\'m going to snooze this until I get back on 07/21/17.', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment(chrono.parseDate('next three weeks'))}},
+      {msg:'Thanks for looking into this.\n\nSo i\'m out of office for the next three weeks. I\'m going to snooze this until I get back on 07/21/17.', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment(chrono.parseDate('next three weeks'))}}
+    ];
+
+    const freeze = new Freeze(github, {});
+
+    validMessages.forEach(obj => {
+      const comment = {
+        user: {
+          login: 'baxterthehacker'
+        },
+        body:obj.msg
+      };
+      expect(freeze.freezable(comment)).toBe(true);
+      expect(freeze.propsHelper(comment.user.login, comment.body)).toEqual(obj.props);
+    });
+  });
+
+  /* With open comment */
+  it('test valid comments with responses', async () => {
+    const defaultFreezeDuration = 7;
+
+    const msgs =
+      [{msg:'snooze until 07/11/17 at 14:00, and remind me to bug Seth again', props:{assignee: 'baxterthehacker', message: 'bug Seth again', unfreezeMoment: moment(chrono.parseDate('07/11/17 at 14:00'))}},
+    {msg:'snooze until 07/11/17 at 14:00 to bug Seth', props:{assignee: 'baxterthehacker', message: 'bug Seth', unfreezeMoment: moment(chrono.parseDate('07/11/17 at 14:00'))}},
+    {msg:'snooze until 07/11/17 at 14:00, and "bug Seth"', props:{assignee: 'baxterthehacker', message: 'bug Seth', unfreezeMoment: moment(chrono.parseDate('07/11/17 at 14:00'))}},
+    {msg:'hey @probot, snooze this issue', props:{assignee: 'baxterthehacker', message: 'Hey, we\'re back awake!', unfreezeMoment: moment().add(defaultFreezeDuration, 'days').format()}}
+      ];
+
+    const freeze = new Freeze(github, {});
+
+    msgs.forEach(obj => {
+      const comment = {
+        user: {
+          login: 'baxterthehacker'
+        },
+        body:obj.msg
+      };
+      expect(freeze.freezable(comment)).toBe(true);
+      expect(freeze.propsHelper(comment.user.login, comment.body)).toEqual(obj.props);
+    });
+  });
+  it('test invalid comments', async () => {
+    const invalidMessages = [
+      {msg:'it\'s really cold out tonight, hope you don\'t freeze', props:{}}
+    ];
+    const freeze = new Freeze(github, {});
+
+    invalidMessages.forEach(obj => {
+      const comment = {
+        user: {
+          login: 'baxterthehacker'
+        },
+        body:obj.msg
+      };
+      expect(freeze.freezable(comment)).toBe(false);
+    });
+  });
+
+  it('these tests are faulty edge cases, and here for reference', async () => {
+    /*
+    Chrono-node can't handle:
+    * til the 25th
+    * for a week
+    */
+    const badChrono = ['snooze this thread until July 25th',
+      'snooze this thread a week'];
+    expect(badChrono).toExist();
   });
 });


### PR DESCRIPTION
This is a spike to use the new [probot-metadata](https://github.com/probot/metadata) to store the snooze config for each issue.

@jbjonesjr I based this off `master` on this fork, which has all of the [PRs I've submitted](https://github.com/jbjonesjr/probot-snooze/pulls/bkeepers) merged together. I tried to cherry pick these changes onto a new branch based off your master, but there were too many conflicts. So I'll wait to submit a PR to this to your upstream repo once the other PRs have been merged.