### PR TITLE
Throw error when failing to parse

### DIFF
--- a/lib/reminders.js
+++ b/lib/reminders.js
@@ -32,8 +32,9 @@ module.exports = {
       }));
     } else {
       await context.github.issues.createComment(context.issue({
-        body: `@${context.payload.sender.login} we had trouble parsing your reminder`
+        body: `@${context.payload.sender.login} we had trouble parsing your reminder. Try:\n\n\`/remind me [what] [when]\``
       }));
+      throw new Error(`Unable to parse reminder: remind ${command.arguments}`);
     }
   },
 

--- a/test/index.js
+++ b/test/index.js
@@ -94,6 +94,24 @@ describe('reminders', () => {
     });
   });
 
+  it('sets a reminder with slash commands', async () => {
+    commentEvent.payload.comment.body = '/remind nope';
+
+    try {
+      await robot.receive(commentEvent);
+      throw new Error('Expected error but none was raised');
+    } catch (err) {
+      expect(err.message).toEqual('Unable to parse reminder: remind nope');
+    }
+
+    expect(github.issues.createComment).toHaveBeenCalledWith({
+      number: 2,
+      owner: 'baxterthehacker',
+      repo: 'public-repo',
+      body: '@baxterthehacker we had trouble parsing your reminder. Try:\n\n`/remind me [what] [when]`'
+    });
+  });
+
   it('test visitor activation', async () => {
     await robot.receive({
       event: 'schedule',


### PR DESCRIPTION
This will ensure parsing failures get reported to sentry so we can track down any other formats that should be supported.