### PR TITLE
use 'MMM Do YYYY' format

### DIFF
--- a/lib/reminders.js
+++ b/lib/reminders.js
@@ -34,7 +34,7 @@ module.exports = {
       await metadata(context).set(reminder)
 
       await context.github.issues.createComment(context.issue({
-        body: `@${context.payload.sender.login} set a reminder for **${moment(reminder.when).calendar()}**`
+        body: `@${context.payload.sender.login} set a reminder for **${moment(reminder.when).format('MMM Do YYYY')}**`
       }))
     } else {
       await context.github.issues.createComment(context.issue({

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -107,7 +107,7 @@ describe('reminders', () => {
       number: 2,
       owner: 'baxterthehacker',
       repo: 'public-repo',
-      body: '@baxterthehacker set a reminder for **07/01/2017**'
+      body: '@baxterthehacker set a reminder for **Jul 1st 2017**'
     })
   })
 


### PR DESCRIPTION
As noted by @Stephen-Gates in issue #13, both `dd/mm/yyyy` and `mm/dd/yyyy` can be confusing depending on which country you live in. In lieu of a more sophisticated solution to detect the user's timezone/locale settings, lets switch the date format to `MMM Do YYYY` which should be less ambiguous for a wider range of users.