### PR TITLE
Remove configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,9 @@ Use the `/remind` slash command to set a reminder on any comment box on GitHub a
 <img width="797" alt="screen shot 2017-09-15 at 6 48 56 pm" src="https://user-images.githubusercontent.com/13410355/30493981-99505cfe-9a46-11e7-8738-3652da872141.png">
 
 ## Usage
-1. **[Configure the GitHub App](https://github.com/apps/reminders)**
-2. Start using the `/reminders` command on the repository.
-3. Optionally, add a `.github/config.yml` to customize the app:
 
-```yml
-reminders:  
-  # Label applied to issues with pending reminders
-  label: reminder
-```
+1. **[Install the GitHub App](https://github.com/apps/reminders)**
+2. Start using the `/reminders` command on the repository.
 
 ## Setup
 

--- a/lib/reminders.js
+++ b/lib/reminders.js
@@ -2,11 +2,7 @@ const moment = require('moment')
 const metadata = require('probot-metadata')
 const parseReminder = require('parse-reminder')
 
-const defaults = {
-  reminders: {
-    label: 'reminder'
-  }
-}
+const LABEL = 'reminder'
 
 module.exports = {
   async set (context, command) {
@@ -17,17 +13,9 @@ module.exports = {
         reminder.who = context.payload.comment.user.login
       }
 
-      let config
-
-      try {
-        config = await context.config('config.yml', defaults)
-      } catch (err) {
-        config = defaults
-      }
-
       const {labels} = context.payload.issue
-      if (!labels.find(({name}) => name === config.reminders.label)) {
-        labels.push(config.reminders.label)
+      if (!labels.find(({name}) => name === LABEL)) {
+        labels.push(LABEL)
       }
       await context.github.issues.edit(context.issue({labels}))
 
@@ -45,16 +33,8 @@ module.exports = {
   },
 
   async check (context) {
-    let config
-
-    try {
-      config = await context.config('config.yml', defaults)
-    } catch (err) {
-      config = defaults
-    }
-
     const {owner, repo} = context.repo()
-    const q = `label:"${config.reminders.label}" repo:${owner}/${repo}`
+    const q = `label:"${LABEL}" repo:${owner}/${repo}`
 
     const resp = await context.github.search.issues({q})
 
@@ -72,11 +52,11 @@ module.exports = {
         await context.github.issues.removeLabel({owner,
           repo,
           number,
-          name: config.reminders.label
+          name: LABEL
         })
       } else if (moment(reminder.when) < moment()) {
         const labels = issue.labels
-        const frozenLabel = labels.find(({name}) => name === config.reminders.label)
+        const frozenLabel = labels.find(({name}) => name === LABEL)
         const pos = labels.indexOf(frozenLabel)
         labels.splice(pos, 1)
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -44,12 +44,6 @@ describe('reminders', () => {
         getInstallations: jest.fn()
       },
       paginate: jest.fn(),
-      repos: {
-        // Response for getting content from '.github/config.yml'
-        getContent: jest.fn().mockImplementation(() => Promise.resolve({
-          data: {content: Buffer.from(`reminders:\n  label: reminder`).toString('base64')}
-        }))
-      },
       issues: {
         createComment: jest.fn(),
         edit: jest.fn(),
@@ -132,11 +126,6 @@ describe('reminders', () => {
   test('test visitor activation', async () => {
     await robot.receive(scheduleEvent)
 
-    expect(github.repos.getContent).toHaveBeenCalledWith({
-      owner: 'baxterthehacker',
-      repo: 'public-repo',
-      path: '.github/config.yml'
-    })
     expect(github.issues.edit).toHaveBeenCalledWith({
       labels: [],
       owner: 'baxterthehacker',


### PR DESCRIPTION
The only setting currently supported is the name of the label to use (`reminder`). There are only [6 repositories](https://github.com/search?utf8=%E2%9C%93&q=reminders+filename%3Aconfig.yml+path%3A.github&type=) that have a `reminders` config in their `.github/config.yml`, and they're all using the default label. This app has to try to load the config file for _every_ single repository that it is installed on. Some accounts are actually hitting abuse rate limits because of this (might be a cause for #16).

This PR removes the configuration.

FYI  @maxanier @reelsense