### PR TITLE
chore(package): update jest to v24.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "eslint-plugin-import": "^2.8.0",
-    "jest": "^22.0.6",
+    "jest": "^24.5.0",
     "smee-client": "^1.0.1",
     "standard": "^11.0.1"
   },


### PR DESCRIPTION
When cloning this repo, running `npm install` and `npm test`, I am seeing the following error:

```
❯ npm test

> probot-reminders@1.0.0 test /Users/macklinu/dev/probot/reminders
> jest && standard

 FAIL  test/index.test.js
  ● Test suite failed to run

    SecurityError: localStorage is not available for opaque origins

      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        0.89s
Ran all test suites.
npm ERR! Test failed.  See above for more details.
```

I believe this is due to https://github.com/facebook/jest/issues/6766, and updating to the latest version of Jest resolves this issue.