### PR TITLE
chore(package): update standard to v12.0.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const commands = require('probot-commands')
 const reminders = require('./lib/reminders')
 
 module.exports = robot => {
-  createScheduler(robot, {interval: 15 * 60 * 1000})
+  createScheduler(robot, { interval: 15 * 60 * 1000 })
   commands(robot, 'remind', reminders.set)
   robot.on('schedule.repository', reminders.check)
 }

--- a/lib/reminders.js
+++ b/lib/reminders.js
@@ -13,11 +13,11 @@ module.exports = {
         reminder.who = context.payload.sender.login
       }
 
-      const {labels} = context.payload.issue
-      if (!labels.find(({name}) => name === LABEL)) {
+      const { labels } = context.payload.issue
+      if (!labels.find(({ name }) => name === LABEL)) {
         labels.push(LABEL)
       }
-      await context.github.issues.edit(context.issue({labels}))
+      await context.github.issues.edit(context.issue({ labels }))
 
       await metadata(context).set(reminder)
 
@@ -33,34 +33,34 @@ module.exports = {
   },
 
   async check (context) {
-    const {owner, repo} = context.repo()
+    const { owner, repo } = context.repo()
     const q = `label:"${LABEL}" repo:${owner}/${repo}`
 
-    const resp = await context.github.search.issues({q})
+    const resp = await context.github.search.issues({ q })
 
     await Promise.all(resp.data.items.map(async issue => {
       // Issue objects from the API don't include owner/repo params, so
       // setting them here with `context.repo` so we don't have to worry
       // about it later. :/
       issue = context.repo(issue)
-      const {owner, repo, number} = issue
+      const { owner, repo, number } = issue
 
       const reminder = await metadata(context, issue).get()
 
       if (!reminder) {
         // Malformed metadata, not much we can do
-        await context.github.issues.removeLabel({owner,
+        await context.github.issues.removeLabel({ owner,
           repo,
           number,
           name: LABEL
         })
       } else if (moment(reminder.when) < moment()) {
         const labels = issue.labels
-        const frozenLabel = labels.find(({name}) => name === LABEL)
+        const frozenLabel = labels.find(({ name }) => name === LABEL)
         const pos = labels.indexOf(frozenLabel)
         labels.splice(pos, 1)
 
-        await context.github.issues.edit({owner, repo, number, labels, state: 'open'})
+        await context.github.issues.edit({ owner, repo, number, labels, state: 'open' })
 
         await context.github.issues.createComment({
           owner,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "eslint-plugin-import": "^2.8.0",
     "jest": "^22.0.6",
     "smee-client": "^1.0.1",
-    "standard": "^11.0.1"
+    "standard": "^12.0.1"
   },
   "engines": {
     "node": "^8.3.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,6 @@
 process.env.TZ = 'UTC'
 
-const {createRobot} = require('probot')
+const { createRobot } = require('probot')
 const plugin = require('..')
 const chrono = require('chrono-node')
 
@@ -16,10 +16,10 @@ describe('reminders', () => {
     payload: {
       action: 'repository',
       repository: {
-        owner: {login: 'baxterthehacker'},
+        owner: { login: 'baxterthehacker' },
         name: 'public-repo'
       },
-      installation: {id: 1}
+      installation: { id: 1 }
     }
   }
 
@@ -49,14 +49,16 @@ describe('reminders', () => {
       issues: {
         createComment: jest.fn(),
         edit: jest.fn(),
-        get: jest.fn().mockImplementation(() => Promise.resolve({data: {
-          body: 'hello world'
-        }})),
+        get: jest.fn().mockImplementation(() => Promise.resolve({
+          data: {
+            body: 'hello world'
+          }
+        })),
         removeLabel: jest.fn()
       },
       search: {
         issues: jest.fn().mockImplementation(() => Promise.resolve({
-          data: {items: [issue]}
+          data: { items: [issue] }
         })) // Q:'label:' + this.labelName
       }
     }


### PR DESCRIPTION
resolves #35 

This PR updates to standard v12 (see the [changelog](https://standardjs.com/changelog.html#1200---2018-08-28)). After installing, I ran `npx standard --fix` to fix any violations.

The build may not succeed until #36 is merged and rebased into this branch.