### PR TITLE
Fix remind command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Use the `/remind` slash command to set a reminder on any comment box on GitHub a
 ## Usage
 
 1. **[Install the GitHub App](https://github.com/apps/reminders)**
-2. Start using the `/reminders` command on the repository.
+2. Start using the `/remind` command on the repository.
 
 ## Setup
 


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

The correct remind command is `/remind` instead of `/reminders`

-----
[View rendered README.md](https://github.com/yeya24/reminders/blob/fix-readme/README.md)